### PR TITLE
docs: fixed example for universal usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can use a really simple pattern to enable your browser modules to run in Nod
 
 ```js
 function createTitle(text, win) {
-  win = win || window;
+  win = win || (typeof window === 'undefined' ? undefined : window);
 
   const title = win.document.createElement('h1');
   title.innerHTML = text;


### PR DESCRIPTION
If we do not set `typeof window === 'undefined'`, then an uncaught exception occurs Node side.